### PR TITLE
utf8 patch and some cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xterm-addon-attach",
-  "version": "0.1.0-beta7",
+  "version": "0.1.0-beta8",
   "author": {
     "name": "The xterm.js authors",
     "url": "https://xtermjs.org/"

--- a/src/AttachAddon.ts
+++ b/src/AttachAddon.ts
@@ -22,7 +22,7 @@ export class AttachAddon implements ITerminalAddon {
 
   constructor(public socket: WebSocket, options?: IAttachOptions) {
     this._bidirectional = options && options.bidirectional;
-    this._utf8 = options && options.utf8;
+    this._utf8 = options && options.inputUtf8;
     if (this._utf8) {
       this.socket.binaryType = 'arraybuffer';
     }

--- a/src/AttachAddon.ts
+++ b/src/AttachAddon.ts
@@ -21,7 +21,7 @@ export class AttachAddon implements ITerminalAddon {
   private _dataListener: (data: string) => void;
 
   constructor(public socket: WebSocket, options?: IAttachOptions) {
-    this._bidirectional = options && options.bidirectional;
+    this._bidirectional = (options && options.bidirectional === false) ? false : true;
     this._utf8 = options && options.inputUtf8;
     if (this._utf8) {
       this.socket.binaryType = 'arraybuffer';

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -12,8 +12,18 @@ export interface ITerminalAddon {
   dispose(): void;
 }
 
+export interface IAttachOptions {
+  bidirectional?: boolean,
+  buffered?: boolean,
+  utf8?: boolean
+}
+
 export class AttachAddon implements ITerminalAddon {
   public activate(terminal: Terminal): void;
   public dispose(): void;
   public attach(socket: WebSocket, bidirectional?: boolean, buffered?: boolean): void;
+}
+
+interface IAttachAddonConstructor {
+  new (socket: WebSocket, options?: IAttachOptions): AttachAddon;
 }

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -15,7 +15,7 @@ export interface ITerminalAddon {
 export interface IAttachOptions {
   bidirectional?: boolean,
   buffered?: boolean,
-  utf8?: boolean
+  inputUtf8?: boolean
 }
 
 export class AttachAddon implements ITerminalAddon {

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -19,10 +19,7 @@ export interface IAttachOptions {
 }
 
 export class AttachAddon implements ITerminalAddon {
+  new(socket: WebSocket, options?: IAttachOptions): AttachAddon;
   public activate(terminal: Terminal): void;
   public dispose(): void;
-}
-
-interface IAttachAddonConstructor {
-  new (socket: WebSocket, options?: IAttachOptions): AttachAddon;
 }

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -13,8 +13,17 @@ export interface ITerminalAddon {
 }
 
 export interface IAttachOptions {
+  /**
+   * Whether input should be written to the backend. Defaults to `true`.
+   */
   bidirectional?: boolean,
-  buffered?: boolean,
+  
+  /**
+   * Whether to use UTF8 binary transport for incoming messages. Defaults to `false`.
+   * Note: This must be in line with the server side of the websocket.
+   *       Always send string messages from the backend if this options is false,
+   *       otherwise always binary UTF8 data.
+   */
   inputUtf8?: boolean
 }
 

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -28,7 +28,7 @@ export interface IAttachOptions {
 }
 
 export class AttachAddon implements ITerminalAddon {
-  new(socket: WebSocket, options?: IAttachOptions): AttachAddon;
+  constructor(socket: WebSocket, options?: IAttachOptions);
   public activate(terminal: Terminal): void;
   public dispose(): void;
 }

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -21,7 +21,6 @@ export interface IAttachOptions {
 export class AttachAddon implements ITerminalAddon {
   public activate(terminal: Terminal): void;
   public dispose(): void;
-  public attach(socket: WebSocket, bidirectional?: boolean, buffered?: boolean): void;
 }
 
 interface IAttachAddonConstructor {


### PR DESCRIPTION
Changes:
- UTF8 support
- ctor driven, `attach` method removed
- remove buffering from the addon (incoming chunks are buffered anyway in `Terminal`)
- removed type tests for incoming messages (should speedup things)

Maybe the last change is way to radical, the idea is to rely on the right message type from the ctor flag `inputUtf8` - if `true` we always assume binary transport for incoming messages, otherwise `string`. This has to be documented to be in line with the backend.

The `any` typing of the terminal object can be removed once the UTF8 PR has landed in the official package.