### PR TITLE
READY message

### DIFF
--- a/src/AttachAddon.test.ts
+++ b/src/AttachAddon.test.ts
@@ -67,7 +67,7 @@ describe('API Integration Tests', () => {
     const waitForReadyAndSend = new Promise(
       resolve => server.on('connection',
         socket => {
-          socket.on('message',msg => {
+          socket.on('message', msg => {
             assert.equal(msg, '#READY#');
             socket.send('foo');
             resolve();

--- a/src/AttachAddon.ts
+++ b/src/AttachAddon.ts
@@ -66,7 +66,7 @@ export class AttachAddon implements ITerminalAddon {
         this._socket.send(READY_MSG);
       } else if (this._socket.readyState === 0) {
         // still connecting, thus wait for open event
-        this._disposables.push(addSocketListener(this._socket, 'open', () => this._socket.send(READY_MSG)));
+        this._disposables.push(addSocketListener(this._socket, 'open', () => this._socket.send(READY_MSG), {once: true}));
       }
     }
   }
@@ -85,8 +85,8 @@ export class AttachAddon implements ITerminalAddon {
   }
 }
 
-function addSocketListener(socket: WebSocket, type: string, handler: (this: WebSocket, ev: MessageEvent | Event | CloseEvent) => any): IDisposable {
-  socket.addEventListener(type, handler);
+function addSocketListener(socket: WebSocket, type: string, handler: (this: WebSocket, ev: MessageEvent | Event | CloseEvent) => any, options?: AddEventListenerOptions): IDisposable {
+  socket.addEventListener(type, handler, options);
   return {
     dispose: () => {
       if (!handler) {

--- a/typings/attach.d.ts
+++ b/typings/attach.d.ts
@@ -16,7 +16,7 @@ export interface IAttachOptions {
   /**
    * Whether input should be written to the backend. Defaults to `true`.
    */
-  bidirectional?: boolean,
+  bidirectional?: boolean;
   
   /**
    * Whether to use UTF8 binary transport for incoming messages. Defaults to `false`.
@@ -24,7 +24,15 @@ export interface IAttachOptions {
    *       Always send string messages from the backend if this options is false,
    *       otherwise always binary UTF8 data.
    */
-  inputUtf8?: boolean
+  inputUtf8?: boolean;
+
+  /**
+   * Whether to send a '#READY#' message upon activation.
+   * If set the server shall not send data before it has seen this message.
+   * Always set this to avoid losing the first messages.
+   * Since this options needs additional preparations on server side it defaults to `false`.
+   */
+  sendReady?: boolean;
 }
 
 export class AttachAddon implements ITerminalAddon {


### PR DESCRIPTION
As described [here](https://github.com/xtermjs/xterm-addon-attach/pull/9#issuecomment-492263090) there is a small chance that an early sent message from the server is lost due to the client not being ready.

This PR introduces an optional flag `sendReady` for the constructor to instruct the addon to send a message `'#READY#'` when it is done with the initialization. Once the server sees this message it is save to go on with normal messaging.

For remote websocket transport on a newly created socket the flag should always be set. (The flag defaults to `false` due to additional preparations needed on server side).
